### PR TITLE
Updating map to use beveled squares for points

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "prepare": "husky install",
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "test": "react-scripts test",
     "cypress:dev": "cypress open",
     "cypress:run": "cypress run",
     "cypress:ci": "react-scripts build & npx serve -s build & wait-on http://localhost:3000 & cypress run",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from "@testing-library/react";
-import App from "./App";
-
-test("renders learn react link", () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/hooks/layers/getLayer.ts
+++ b/src/hooks/layers/getLayer.ts
@@ -31,8 +31,9 @@ export default function getLayers(
     .map((l) => [l.selection_dependent_on, l.source_layer]);
   const subgroups = layers.filter((l) => l.is_subgroup);
   const layersWithProtos = layers.map((l) => {
-    const filters_to_add = Object.assign({}, { filter: filters[l.id] });
-    return new protos[l.layer_type](Object.assign(l, args, filters_to_add));
+    // const filters_to_add = Object.assign({}, { filter: filters[l.id] });
+    // return new protos[l.layer_type](Object.assign(l, args, filters_to_add));
+    return new protos[l.layer_type](Object.assign(l, args));
   });
   const layers_to_return = layersWithProtos.map((l) => l.MBLayer);
   const legends_to_return = layersWithProtos

--- a/src/hooks/layers/getLayer.ts
+++ b/src/hooks/layers/getLayer.ts
@@ -11,7 +11,6 @@ export default function getLayers(
   key: LayerGroupName,
   args: Record<string, any>,
   protos: Record<string, any>,
-  filters: Record<string, any>,
 ) {
   const rawLayers = allLayers[key];
   const layers = Array.isArray(rawLayers)
@@ -31,8 +30,6 @@ export default function getLayers(
     .map((l) => [l.selection_dependent_on, l.source_layer]);
   const subgroups = layers.filter((l) => l.is_subgroup);
   const layersWithProtos = layers.map((l) => {
-    // const filters_to_add = Object.assign({}, { filter: filters[l.id] });
-    // return new protos[l.layer_type](Object.assign(l, args, filters_to_add));
     return new protos[l.layer_type](Object.assign(l, args));
   });
   const layers_to_return = layersWithProtos.map((l) => l.MBLayer);

--- a/src/hooks/layers/useLayers.js
+++ b/src/hooks/layers/useLayers.js
@@ -104,7 +104,6 @@ export function useLayers(
       layerGroup,
       { floodGroup: subgroup || loggedLayers[1] },
       custom_protos,
-      filters,
     );
   }, [
     layerToggleToUse,

--- a/src/hooks/utils/formattingUtils.js
+++ b/src/hooks/utils/formattingUtils.js
@@ -6,7 +6,7 @@ export function kFormatter(num, type = "$", toFixed = 1) {
     if (absNum > 999999)
       return (Math.abs(num) / 1000000).toFixed(toFixed) + "M";
     if (absNum > 999) return (Math.abs(num) / 1000).toFixed(toFixed) + "K";
-    return absNum.toFixed(0);
+    return absNum.toFixed(toFixed);
   }
   if (type === "%") {
     return (num * 100).toFixed(toFixed);

--- a/src/layers/colormaps/colormaps.js
+++ b/src/layers/colormaps/colormaps.js
@@ -189,16 +189,15 @@ const _Blue_5Step_per_ha = {
 };
 
 const _Floodmaps_Bathy = {
-  breaks: [0, 2, 4, 6],
+  breaks: [0, 1.5, 3],
 
   colorRamp: [
     "rgba(255, 255, 0, 1)",
     "rgba(255, 200, 0, 1)",
-    "rgba(255, 120, 0, 1)",
     "rgba(255, 0, 0, 1)",
   ],
 
-  sizeRamp: [10, 10, 10, 10],
+  sizeRamp: [10, 10, 10],
 
   legendScale: 3,
 };

--- a/src/layers/layers.tsx
+++ b/src/layers/layers.tsx
@@ -6,6 +6,7 @@ import {
   Green,
   Grey,
   Blue_5Step_Pop,
+  Red_10Step,
 } from "./colormaps/colormaps";
 import {
   ConfigurableLayerMap,
@@ -182,38 +183,43 @@ export const LAYERS: Record<LayerName, Layer> = {
     layer_type: "FILL_WITH_OUTLINE",
     display_legend: false,
     subgroup: "flooding_2015",
-    opacity: 1,
+    opacity: 0.4,
     minzoom: FLOODING_MIN_ZOOM,
     maxzoom: 18,
   },
   [LayerName.FLOODING_NOMANG]: {
     id: "flooding_nomang",
-    source: "flooding_nomang_pt",
-    source_layer: `Without_TC_Tr_${RP}`,
+    source: "flooding_squares",
+    source_layer: `CWON_all_reindexed`,
     legend: FloodMaps_Bathy,
-    colorValue: ["to-number", ["get", "value"]],
+    colorValue: ["to-number", ["get", `without_2015_TC_Tr_${RP}`]],
     layer_title: "Expected Flooding",
     layer_subtitle: `1 in ${parseInt(RP)} year storm`,
     layer_toggle: "Show Flooding without Mangroves",
     display_legend: true,
-    layer_type: "GEO_POINT",
+    layer_type: "FILL_WITH_OUTLINE",
     legend_suffix: "m",
     subgroup: "flooding_nomang",
     minzoom: FLOODING_MIN_ZOOM,
+    maxzoom: 18,
+    filter: [">", ["to-number", ["get", `without_2015_TC_Tr_${RP}`]], 0],
   },
   [LayerName.FLOODING_2015]: {
     id: "flooding_2015",
-    source: "flooding_2015_pt",
-    source_layer: `with_2015_TC_Tr_${RP}`,
+    source: "flooding_squares",
+    source_layer: `CWON_all_reindexed`,
     legend: FloodMaps_Bathy,
-    colorValue: ["to-number", ["get", "value"]],
+    colorValue: ["to-number", ["get", `with_2015_TC_Tr_${RP}`]],
     layer_title: "Expected Flooding",
     layer_subtitle: `1 in ${parseInt(RP)} year storm`,
     layer_toggle: "Show Flooding with Mangroves",
-    layer_type: "GEO_POINT",
+    layer_type: "FILL_WITH_OUTLINE",
+    display_legend: false,
     legend_suffix: "m",
     subgroup: "flooding_2015",
     minzoom: FLOODING_MIN_ZOOM,
+    maxzoom: 18,
+    filter: [">", ["to-number", ["get", `with_2015_TC_Tr_${RP}`]], 0],
   },
 };
 
@@ -267,7 +273,7 @@ const layerGroups: Record<LayerGroupName, LayerGroup> = {
   [LayerGroupName.CurrentRisk]: {
     name: LayerGroupName.CurrentRisk,
     shortDescription:
-      "The current annual risk from flooding at the coast, including existing benefits from mangroves.",
+      "The current annual risk from flooding at the coast, including present mangroves.",
     IconComponent: () => (
       <Icon icon="mdi:hazard-lights" color="white" className="w-full h-full" />
     ),
@@ -319,7 +325,7 @@ const layerGroups: Record<LayerGroupName, LayerGroup> = {
   [LayerGroupName.Population]: {
     name: LayerGroupName.Population,
     shortDescription:
-      "Annual Expected Benefit (AEB) is the flood risk reduced by mangroves annually in a location (in avoided damages to people).",
+      "Annual Expected Benefit (AEB) is the flood risk reduced by mangroves annually in a location (in avoided people exposed to flooding).",
     IconComponent: () => (
       <Icon
         icon="pepicons-pencil:people"

--- a/src/layers/layers.tsx
+++ b/src/layers/layers.tsx
@@ -190,7 +190,7 @@ export const LAYERS: Record<LayerName, Layer> = {
   [LayerName.FLOODING_NOMANG]: {
     id: "flooding_nomang",
     source: "flooding_squares",
-    source_layer: `CWON_all_reindexed`,
+    source_layer: `CWON_Tr50_reindexed`,
     legend: FloodMaps_Bathy,
     colorValue: ["to-number", ["get", `without_2015_TC_Tr_${RP}`]],
     layer_title: "Expected Flooding",
@@ -207,7 +207,7 @@ export const LAYERS: Record<LayerName, Layer> = {
   [LayerName.FLOODING_2015]: {
     id: "flooding_2015",
     source: "flooding_squares",
-    source_layer: `CWON_all_reindexed`,
+    source_layer: `CWON_Tr50_reindexed`,
     legend: FloodMaps_Bathy,
     colorValue: ["to-number", ["get", `with_2015_TC_Tr_${RP}`]],
     layer_title: "Expected Flooding",

--- a/src/layers/protos/FillWithOutlineProto.js
+++ b/src/layers/protos/FillWithOutlineProto.js
@@ -8,14 +8,14 @@ export default class FillWithOutlineProto {
     format,
     layer_title,
     layer_type,
-    opacity,
     floodGroup,
     subgroup,
     display_legend = true,
-    filter_value = 250000,
+    filter = null,
     legend_prefix = null,
     legend_suffix = null,
     minzoom = 0,
+    opacity = 0.8,
     maxzoom = 12,
   }) {
     this.id = id;
@@ -30,7 +30,7 @@ export default class FillWithOutlineProto {
     this.layer_type = layer_type;
     this.color_header = legend.colorHeader(colorValue);
     this.display_legend = display_legend;
-    this.filter_value = filter_value;
+    this.filter = filter;
     this.format = format;
     this.opacity = opacity;
     this.minzoom = minzoom;
@@ -44,7 +44,7 @@ export default class FillWithOutlineProto {
   }
 
   get MBLayer() {
-    const layer_proto = {
+    let layer_proto = {
       id: this.id,
       key: this.id,
       type: "fill",
@@ -67,6 +67,10 @@ export default class FillWithOutlineProto {
       minzoom: this.minzoom,
       maxzoom: this.maxzoom,
     };
+
+    if (this.filter) {
+      layer_proto.filter = this.filter;
+    }
 
     return Object.assign(layer_proto, {
       layout: {

--- a/src/layers/sources.js
+++ b/src/layers/sources.js
@@ -34,6 +34,15 @@ const flooding_nomang_pt = {
   maxzoom: 14,
 };
 
+const flooding_squares = {
+  id: "flooding_squares",
+  type: "vector",
+  format: "mvt",
+  tiles: [`${PMSERVER_URL}/CWON_reindexed/CWON_all_reindexed/{z}/{x}/{y}.mvt`],
+  minzoom: 0,
+  maxzoom: 14,
+};
+
 const mangroves_1996 = {
   id: "mangroves_1996",
   type: "vector",
@@ -102,6 +111,7 @@ const sources = [
   ["mangroves_1996", mangroves_1996],
   ["flooding_2015_pt", flooding_2015_pt],
   ["flooding_nomang_pt", flooding_nomang_pt],
+  ["flooding_squares", flooding_squares],
   ["UCSC_CWON_studyunits", CWON_tesela_bounds],
   ["UCSC_CWON_studyunits_reppts", CWON_tesela_reppts],
   ["UCSC_CWON_studyunits_hexs", CWON_tesela_hexs],

--- a/src/layers/sources.js
+++ b/src/layers/sources.js
@@ -38,7 +38,7 @@ const flooding_squares = {
   id: "flooding_squares",
   type: "vector",
   format: "mvt",
-  tiles: [`${PMSERVER_URL}/CWON_reindexed/CWON_all_reindexed/{z}/{x}/{y}.mvt`],
+  tiles: [`${PMSERVER_URL}/CWON_reindexed/CWON_Tr50_reindexed/{z}/{x}/{y}.mvt`],
   minzoom: 0,
   maxzoom: 14,
 };

--- a/src/legends/protos/all_protos.js
+++ b/src/legends/protos/all_protos.js
@@ -8,4 +8,5 @@ export const all_protos = Object.assign(
   { RASTER2: InterpolateLegend },
   { HEX_3D: HexLegend },
   { GEO_POINT: DiscretePointLegend },
+  { FILL_WITH_OUTLINE: DiscretePointLegend },
 );


### PR DESCRIPTION
FYI Will, this just has limited updates to use IMO a better view for the floods (beveled squares).

I also ripped out the global filters in `getLayer.ts` (ie Mangrove Loss > 15%).  It was getting slightly convoluted and conflicting with filters at the individual layer level.  I want to get a rework of `getLayer` in soon, and feel okay about this, but lmk your thoughts